### PR TITLE
implement heartbeat event

### DIFF
--- a/firmware/inc/core_registers.h
+++ b/firmware/inc/core_registers.h
@@ -13,8 +13,8 @@ static const uint8_t CORE_REG_COUNT = 16;
 #define DUMP_OFFSET (3)
 #define MUTE_RPL_OFFSET (4)
 #define VISUAL_EN_OFFSET (5)
-#define OPLEDEN (6)
-#define ALIVE_EN (7)
+#define OPLEDEN_OFFSET (6)
+#define ALIVE_EN_OFFSET (7)
 
 // RESET_DEF bitfields
 #define RST_DEF_OFFSET (0)

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -9,7 +9,14 @@
 
 // Pico-specific includes.
 #include <hardware/structs/timer.h>
+#include <pico/divider.h> // for fast hardware division with remainder.
 #include <hardware/timer.h>
+
+#define NO_MSG_INTERVAL_US (3'000'000UL) // Threshold duration. If no messages
+                                         // have been received for this
+                                         // duration, op mode should switch to
+                                         // IDLE.
+#define HEARTBEAT_INTERVAL_US (1'000'000UL)
 
 // Create a typedef to simplify syntax for array of static function ptrs.
 typedef void (*read_reg_fn)(uint8_t reg);
@@ -249,6 +256,18 @@ private:
  * \brief #rx_buffer_ index where the next incoming byte will be written.
  */
     uint8_t rx_buffer_index_;
+
+/**
+ * \brief next time a heartbeat message is scheduled to issue.
+ * \note only valid if Op Mode is in the ACTIVE state.
+ */
+    uint32_t next_heartbeat_time_us_;
+
+/**
+ * \brief last time a message was received in microseconds.
+ * \note only valid if Op Mode is in the ACTIVE state.
+ */
+    uint32_t last_msg_in_time_us_;
 
 /**
  * \brief Read incoming bytes from the USB serial port. Does not block.


### PR DESCRIPTION
We now issue an EVENT message once per second while in the active state. This event gets issued from the TIMESTAMP_SECOND register and happens on the second.

If the device has not received any messages in the last 3 seconds, it will drop into standby mode and stop issuing events (including this heartbeat).

@bruno-f-cruz does bonsai have some sort of handshaking protocol with Harp every second or so to keep devices in ACTIVE mode?