### PR TITLE
Dev/harp time

### DIFF
--- a/examples/harp_c_app_example/src/main.cpp
+++ b/examples/harp_c_app_example/src/main.cpp
@@ -74,6 +74,7 @@ int main()
 {
 // Init Synchronizer.
     HarpSynchronizer& sync = HarpSynchronizer::init(uart1, 5);
+    app.set_synchronizer(&sync);
 #ifdef DEBUG
     stdio_uart_init_full(uart0, 921600, 0, -1); // use uart1 tx only.
     printf("Hello, from an RP2040!\r\n");

--- a/firmware/inc/harp_c_app.h
+++ b/firmware/inc/harp_c_app.h
@@ -26,8 +26,6 @@ private:
  * \param update_fn pointer to function that will be called periodically to
  *  update the app state.
  * \param reset_fn pointer to function that will reset the app state.
- * \param set_visual_indicators_fn (optional) pointer to function that will
- *  enable/disable any device external visual indicators.
  */
     HarpCApp(uint16_t who_am_i,
              uint8_t hw_version_major, uint8_t hw_version_minor,
@@ -37,8 +35,7 @@ private:
              uint16_t serial_number, const char name[],
              void* app_reg_values, RegSpecs* app_reg_specs,
              RegFnPair* reg_fns, size_t app_reg_count,
-             void (* update_fn)(void), void (* reset_fn)(void),
-             void (* set_visual_indicators_fn)(bool) = nullptr);
+             void (* update_fn)(void), void (* reset_fn)(void));
 
     ~HarpCApp();
 
@@ -74,19 +71,23 @@ private:
  * \brief update app state. Readable registers can be updated here.
  *  Implements virtual member fn in base class of the same name.
  */
-    void update_app_state();
+    void update_app_state()
+    {update_fn_();}
 
 /**
  * \brief Reset the app state.
  *  Implements virtual member fn in base class of the same name.
  */
-    void reset_app();
+    void reset_app()
+    {reset_fn_();}
 
 /**
  * \brief Enable or disable external visual indicators.
  *  Implements virtual member fn in base class of the same name.
  */
-    void set_visual_indicators(bool enabled);
+    void set_visual_indicators(bool enabled)
+    {if (set_visual_indicators_fn_ != nullptr)
+        set_visual_indicators_fn_(enabled);}
 
 /**
  * \brief send one harp reply read message per app register.
@@ -110,7 +111,6 @@ private:
     size_t reg_count_;
     void (* update_fn_)(void);
     void (* reset_fn_)(void);
-    void (* set_visual_indicators_fn_)(bool);
 };
 
 #endif //HARP_C_APP_H

--- a/firmware/inc/harp_synchronizer.h
+++ b/firmware/inc/harp_synchronizer.h
@@ -53,6 +53,22 @@ public:
  */
     static HarpSynchronizer& instance(){return *self;}
 
+/**
+ * \brief get the total elapsed microseconds (64-bit) in "Harp" time.
+ * \warning this value is not monotonic and can change at any time if an
+ *  external synchronizer is physically connected and operating.
+ */
+    uint64_t time_us_64()
+    {return ::time_us_64() - offset_us_64_;}
+
+/**
+ * \brief get the total elapsed microseconds (32-bit) in "Harp" time.
+ * \warning this value is not monotonic and can change at any time if an
+ *  external synchronizer is physically connected and operating.
+ */
+    uint32_t time_us_32()
+    {return ::time_us_32() - uint32_t(offset_us_64_);}
+
 private:
 /**
  * \brief a pointer to the one-and-only instance or nullptr if init() was
@@ -72,11 +88,20 @@ private:
     volatile SyncState state_;
     volatile uint8_t packet_index_;
     volatile bool new_timestamp_;
+
+    uint64_t offset_us_64_;
 /**
  * \brief container to store the little-endian timestamp and then
  *  reinterpret-cast to the value.
  */
     alignas(uint32_t) volatile uint8_t sync_data_[4];
+
+/**
+ * \brief HarpCore is a friend such that updating the HarpCore's timestamp
+ *  registers will update the HarpSynchronizer #offset_us_64_ instead of
+ *  the HarpCore's internal offset.
+ */
+    friend class HarpCore;
 };
 
 #endif // HARP_SYNCHRONIZER_H

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -27,15 +27,13 @@ HarpCApp::HarpCApp(uint16_t who_am_i,
                    uint16_t serial_number, const char name[],
                    void* app_reg_values, RegSpecs* app_reg_specs,
                    RegFnPair* app_reg_fns, size_t app_reg_count,
-                   void (*update_fn)(void), void (* reset_fn)(void),
-                   void (*set_visual_indicators_fn)(bool))
+                   void (*update_fn)(void), void (* reset_fn)(void))
 :reg_values_{app_reg_values},
  reg_specs_{app_reg_specs},
  reg_fns_{app_reg_fns},
  reg_count_{app_reg_count},
  update_fn_{update_fn},
  reset_fn_{update_fn},
- set_visual_indicators_fn_{set_visual_indicators_fn},
  HarpCore(who_am_i, hw_version_major, hw_version_minor,
           assembly_version, harp_version_major, harp_version_minor,
           fw_version_major, fw_version_minor, serial_number, name)
@@ -72,23 +70,6 @@ void HarpCApp::handle_buffered_app_message()
         }
     }
     clear_msg();
-}
-
-void HarpCApp::update_app_state()
-{
-    update_fn_();
-}
-
-void HarpCApp::reset_app()
-{
-    reset_fn_();
-}
-
-void HarpCApp::set_visual_indicators(bool state)
-{
-    // nullptr check since this function is optional.
-    if (set_visual_indicators_fn_ != nullptr)
-        set_visual_indicators_fn_(state);
 }
 
 void HarpCApp::dump_app_registers()

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -145,9 +145,9 @@ void HarpCore::update_state()
 {
     // Update internal logic.
     uint32_t curr_time_us = time_us_32();
-    if (tud_cdc_connected())
+    if (tud_ready())
         disconnect_handled_ = false;
-    if (!tud_cdc_connected() && !disconnect_handled_)
+    if (!tud_ready() && !disconnect_handled_)
     {
         disconnect_handled_ = true;
         disconnect_start_time_us_ = curr_time_us;

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -25,7 +25,8 @@ HarpCore::HarpCore(uint16_t who_am_i,
 :regs_{who_am_i, hw_version_major, hw_version_minor,assembly_version,
        harp_version_major, harp_version_minor,
        fw_version_major, fw_version_minor, serial_number, name},
- rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_}, new_msg_{false}
+ rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_}, new_msg_{false},
+ set_visual_indicators_fn_{nullptr}, sync_{nullptr}, offset_us_64_{0}
 {
     // Create a pointer to the first (and one-and-only) instance created.
     if (self == nullptr)
@@ -286,15 +287,16 @@ void HarpCore::write_to_read_only_reg_error(msg_t& msg)
 
 void HarpCore::update_timestamp_regs()
 {
-    // PICO implementation:
-    //  extract time data from pico timer which increments every 1[us].
-    // Note that R_TIMESTAMP_MICRO can only represent values up to 31249.
-    // Update microseconds first.
-    uint64_t curr_total_us = time_us_64();
+    // RP2040 implementation:
+    // Harp Time is computed as an offset relative to the RP2040's main
+    // timer register, which ticks every 1[us].
+    // Note: R_TIMESTAMP_MICRO can only represent values up to 31249.
+    // Note: Update microseconds first.
+    uint64_t curr_total_us = harp_time_us_64();
     uint32_t curr_total_us_32 = (uint32_t)curr_total_us; // truncate.
     // TODO: use divmod_u64u64_rem to do division with remainder once.
     regs.R_TIMESTAMP_MICRO = uint16_t((curr_total_us_32%1000000UL)>>5);
-    regs.R_TIMESTAMP_SECOND = time_us_64() / 1000000ULL;
+    regs.R_TIMESTAMP_SECOND = curr_total_us / 1000000ULL;
 }
 
 void HarpCore::read_timestamp_second(uint8_t reg_name)
@@ -306,16 +308,17 @@ void HarpCore::read_timestamp_second(uint8_t reg_name)
 void HarpCore::write_timestamp_second(msg_t& msg)
 {
     const uint32_t& seconds = *((uint32_t*)msg.payload);
-    // PICO implementation: replace the current number of elapsed seconds
-    // without altering the number of elapsed microseconds.
+    // Replace the current number of elapsed seconds without altering the
+    // number of elapsed microseconds.
     // TODO: use divmod_u64u64_rem to do division with remainder once.
     uint64_t set_time_microseconds = uint64_t(seconds) * 1000000UL;
     uint32_t current_microseconds = time_us_64() % 1000000ULL;
-    uint64_t new_time = set_time_microseconds + current_microseconds;
-    // Set the low and high time registers with the desired seconds.
-    // Time does not update until timehw is written to.
-    timer_hw->timelw = (uint32_t)new_time;  // Truncate.
-    timer_hw->timehw = (uint32_t)(new_time >> 32);
+    uint64_t new_harp_time_us = set_time_microseconds + current_microseconds;
+    // If synchronizer is attached, update the synchronizer's time.
+    if (self->sync_ != nullptr)
+        self->sync_->offset_us_64_ = time_us_64() - new_harp_time_us;
+    else
+        self->offset_us_64_ = time_us_64() - new_harp_time_us;
     // Send harp reply.
     // Note: harp timestamp registers will be updated before being dispatched.
     send_harp_reply(WRITE, msg.header.address);
@@ -333,11 +336,16 @@ void HarpCore::write_timestamp_microsecond(msg_t& msg)
     const uint32_t msg_us = ((uint32_t)(*((uint16_t*)msg.payload))) << 5;
     // PICO implementation: replace the current number of elapsed microseconds
     // with the value received from the message.
-    // timelw and timehw need to be written to such that the update takes place.
     uint64_t curr_total_s = time_us_64() / 1000000ULL; // integer division.
-    uint64_t new_time = curr_total_s + msg_us;
-    timer_hw->timelw = (uint32_t)new_time;
-    timer_hw->timehw = (uint32_t)(new_time >> 32);
+    uint64_t new_harp_time_us = curr_total_s + msg_us;
+    // If synchronizer is attached, update the synchronizer's time.
+    if (self->sync_ != nullptr)
+        self->sync_->offset_us_64_ = time_us_64() - new_harp_time_us;
+    else
+        self->offset_us_64_ = time_us_64() - new_harp_time_us;
+    //// timelw and timehw need to be written to such that the update takes place.
+    //timer_hw->timelw = (uint32_t)new_harp_time_us;
+    //timer_hw->timehw = (uint32_t)(new_harp_time_us >> 32);
     // Send harp reply.
     // Note: Harp timestamp registers will be updated before dispatching reply.
     send_harp_reply(WRITE, msg.header.address);


### PR DESCRIPTION
"Harp Time" (i.e: what gets written to the timestamp registers and dispatched with timestamped messages) is now implemented with an offset from the RP2040's 1[us] monotonic timer instead of adjusting the monotonic timer value directly. This preserves the behavior (without surprises!) of the Pico SDK's `time_us_32()` and `time_us_64()` functions in addition to the alarm-based repeating timer functionality.