### PR TITLE
add extra sync helper functions

### DIFF
--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -211,6 +211,36 @@ public:
                 self->sync_->time_us_32();}
 
 /**
+ * \brief convert harp time (in 64-bit microseconds) to local system time
+ *  (in 64-bit microseconds).
+ * \details this utility function is useful for setting alarms in the device's
+ *  local time domain, which is monotonic and unchanged by adjustments to
+ *  the harp time.
+ * \note if synchronizer is attached, the conversion will be in reference to
+ *  the externally synchronized time.
+ * \param harp_time_us the current time in microseconds
+ */
+    static uint64_t harp_to_system_us_64(uint64_t harp_time_us)
+    {return (self->sync_ == nullptr)?
+                harp_time_us + self->offset_us_64_:
+                self->sync_->harp_to_system_us_64(harp_time_us);}
+
+/**
+ * \brief convert harp time (in 32-bit microseconds) to local system time
+ *  (in 32-bit microseconds).
+ * \details this utility function is useful for setting alarms in the device's
+ *  local time domain, which is monotonic and unchanged by adjustments to
+ *  the harp time.
+ * \note if synchronizer is attached, the conversion will be in reference to
+ *  the externally synchronized time.
+ * \param harp_time_us the current time in microseconds
+ */
+    static uint32_t harp_to_system_us_32(uint32_t harp_time_us)
+    {return (self->sync_ == nullptr)?
+                harp_time_us + uint32_t(self->offset_us_64_):
+                self->sync_->harp_to_system_us_32(harp_time_us);}
+
+/**
  * \brief attach a synchronizer. If the synchronizer is attached, then calls to
  *  harp_time_us_64() and harp_time_us_32() will reflect the synchronizer's
  *  time.

--- a/firmware/inc/harp_synchronizer.h
+++ b/firmware/inc/harp_synchronizer.h
@@ -58,16 +58,43 @@ public:
  * \warning this value is not monotonic and can change at any time if an
  *  external synchronizer is physically connected and operating.
  */
-    uint64_t time_us_64()
-    {return ::time_us_64() - offset_us_64_;}
+    static uint64_t time_us_64()
+    {return ::time_us_64() - self->offset_us_64_;}
 
 /**
  * \brief get the total elapsed microseconds (32-bit) in "Harp" time.
  * \warning this value is not monotonic and can change at any time if an
  *  external synchronizer is physically connected and operating.
  */
-    uint32_t time_us_32()
-    {return ::time_us_32() - uint32_t(offset_us_64_);}
+    static uint32_t time_us_32()
+    {return ::time_us_32() - uint32_t(self->offset_us_64_);}
+
+/**
+ * \brief convert harp time (in 64-bit microseconds) to local system time
+ *  (in 64-bit microseconds).
+ * \details this utility function is useful for setting alarms in the device's
+ *  local time domain, which is monotonic and unchanged by adjustments to
+ *  the harp time.
+ */
+    static uint64_t harp_to_system_us_64(uint64_t harp_time_us)
+    {return harp_time_us + self->offset_us_64_;}
+
+/**
+ * \brief convert harp time (in 32-bit microseconds) to local system time
+ *  (in 32-bit microseconds).
+ * \details this utility function is useful for setting alarms in the device's
+ *  local time domain, which is monotonic and unchanged by adjustments to
+ *  the harp time.
+ */
+    static uint32_t harp_to_system_us_32(uint32_t harp_time_us)
+    {return harp_time_us + uint32_t(self->offset_us_64_);}
+
+/**
+ * \brief true if the synchronizer has received at least one external sync
+ *  signal.
+ */
+    static bool has_synced()
+    {return self->has_synced_;}
 
 private:
 /**
@@ -90,6 +117,8 @@ private:
     volatile bool new_timestamp_;
 
     uint64_t offset_us_64_;
+
+    bool has_synced_;
 /**
  * \brief container to store the little-endian timestamp and then
  *  reinterpret-cast to the value.

--- a/firmware/inc/harp_synchronizer.h
+++ b/firmware/inc/harp_synchronizer.h
@@ -118,7 +118,7 @@ private:
 
     uint64_t offset_us_64_;
 
-    bool has_synced_;
+    volatile bool has_synced_;
 /**
  * \brief container to store the little-endian timestamp and then
  *  reinterpret-cast to the value.

--- a/firmware/inc/harp_synchronizer.h
+++ b/firmware/inc/harp_synchronizer.h
@@ -112,11 +112,12 @@ private:
 
     uart_inst_t* uart_id_;
 
+    // members edited within an ISR must be volatile.
     volatile SyncState state_;
     volatile uint8_t packet_index_;
     volatile bool new_timestamp_;
 
-    uint64_t offset_us_64_;
+    volatile uint64_t offset_us_64_;
 
     volatile bool has_synced_;
 /**

--- a/firmware/src/harp_synchronizer.cpp
+++ b/firmware/src/harp_synchronizer.cpp
@@ -3,7 +3,8 @@
 
 HarpSynchronizer::HarpSynchronizer(uart_inst_t* uart_id, uint8_t uart_rx_pin)
 :uart_id_{uart_id}, packet_index_{0}, sync_data_{0, 0, 0, 0},
- state_{RECEIVE_HEADER_0}, new_timestamp_{false}, offset_us_64_{0}
+ state_{RECEIVE_HEADER_0}, new_timestamp_{false}, offset_us_64_{0},
+ has_synced_{false}
 {
     // Create a pointer to the first (and one-and-only) instance created.
     if (self == nullptr)
@@ -91,6 +92,7 @@ void HarpSynchronizer::uart_rx_callback()
     printf("harp time is: %llu [us]\r\n", curr_harp_us);
     #endif
     self->offset_us_64_ = ::time_us_64() - curr_harp_us;
+    self->has_synced_ = true;
     // Cleanup.
     self->new_timestamp_ = false;
     restore_interrupts(interrupt_status);


### PR DESCRIPTION
Needs hardware testing.

Adds some helper functions to convert from harp time to pico time to make scheduling functions with the pico-sdk's timer and alarm api easier.