### PR TITLE
add uuid and tag registers

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -9,12 +9,6 @@ if(NOT DEFINED PICO_SDK_PATH)
              pico_sdk_init() must first be invoked.")
 endif()
 
-if(NOT DEFINED PICO_SDK_PATH)
-    message(WARNING
-            "COMMIT_ID variable is not defined.
-             TAG Register will not contain a valid project hash.")
-endif()
-
 # commented out for now. Unclear how to use this with the GUI.
 #option(DEBUG "If true, compile with added debug statements output to
 #              uart at 921600 baud" OFF)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-
 #uncomment to print incoming and outgoing harp message stats.
 #add_definitions(-DDEBUG_HARP_MSG_IN)
 #add_definitions(-DDEBUG_HARP_MSG_OUT)
@@ -8,6 +7,12 @@ if(NOT DEFINED PICO_SDK_PATH)
     message(FATAL_ERROR
             "PICO_SDK_PATH was not specified.
              pico_sdk_init() must first be invoked.")
+endif()
+
+if(NOT DEFINED PICO_SDK_PATH)
+    message(WARNING
+            "COMMIT_ID variable is not defined.
+             TAG Register will not contain a valid project hash.")
 endif()
 
 # commented out for now. Unclear how to use this with the GUI.

--- a/firmware/inc/core_registers.h
+++ b/firmware/inc/core_registers.h
@@ -5,7 +5,7 @@
 #include <core_reg_bits.h>
 #include <cstring>  // for strcpy
 
-static const uint8_t CORE_REG_COUNT = 16;
+static const uint8_t CORE_REG_COUNT = 18;
 
 #define APP_REG_START_ADDRESS (32)
 
@@ -52,7 +52,9 @@ enum RegName : uint8_t
     DEVICE_NAME = 12,
     SERIAL_NUMBER = 13,
     CLOCK_CONFIG = 14,
-    TIMESTAMP_OFFSET = 15
+    TIMESTAMP_OFFSET = 15,
+    UUID = 16,
+    TAG = 17,
 };
 
 
@@ -76,6 +78,8 @@ struct RegValues
     volatile uint16_t R_SERIAL_NUMBER;
     volatile uint8_t R_CLOCK_CONFIG;
     volatile uint8_t R_TIMESTAMP_OFFSET;
+    const uint8_t R_UUID[16];
+    const uint8_t R_TAG[8];
 };
 #pragma pack(pop)
 
@@ -94,7 +98,8 @@ struct Registers
                   uint8_t assembly_version,
                   uint8_t harp_version_major, uint8_t harp_version_minor,
                   uint8_t fw_version_major, uint8_t fw_version_minor,
-                  uint16_t serial_number, const char name[]);
+                  uint16_t serial_number, const char name[],
+                  const uint8_t tag[]);
         ~Registers();
 
     RegValues regs_;
@@ -118,7 +123,10 @@ struct Registers
      {(uint8_t*)&regs_.R_DEVICE_NAME,      sizeof(regs_.R_DEVICE_NAME),       U8},
      {(uint8_t*)&regs_.R_SERIAL_NUMBER,    sizeof(regs_.R_SERIAL_NUMBER),     U16},
      {(uint8_t*)&regs_.R_CLOCK_CONFIG,     sizeof(regs_.R_CLOCK_CONFIG),      U8},
-     {(uint8_t*)&regs_.R_TIMESTAMP_OFFSET, sizeof(regs_.R_TIMESTAMP_OFFSET),  U8}};
+     {(uint8_t*)&regs_.R_TIMESTAMP_OFFSET, sizeof(regs_.R_TIMESTAMP_OFFSET),  U8},
+     {(uint8_t*)&regs_.R_UUID, sizeof(regs_.R_UUID),  U8},
+     {(uint8_t*)&regs_.R_TAG, sizeof(regs_.R_TAG),  U8},
+    };
 
     // Syntactic Sugar. Make bitfields for certain registers easier to access.
     OperationCtrlBits& r_operation_ctrl_bits = *((OperationCtrlBits*)(&regs_.R_OPERATION_CTRL));

--- a/firmware/inc/core_registers.h
+++ b/firmware/inc/core_registers.h
@@ -78,8 +78,8 @@ struct RegValues
     volatile uint16_t R_SERIAL_NUMBER;
     volatile uint8_t R_CLOCK_CONFIG;
     volatile uint8_t R_TIMESTAMP_OFFSET;
-    const uint8_t R_UUID[16];
-    const uint8_t R_TAG[8];
+    uint8_t R_UUID[16];
+    uint8_t R_TAG[8];
 };
 #pragma pack(pop)
 

--- a/firmware/inc/harp_c_app.h
+++ b/firmware/inc/harp_c_app.h
@@ -33,6 +33,7 @@ private:
              uint8_t harp_version_major, uint8_t harp_version_minor,
              uint8_t fw_version_major, uint8_t fw_version_minor,
              uint16_t serial_number, const char name[],
+             const uint8_t tag[],
              void* app_reg_values, RegSpecs* app_reg_specs,
              RegFnPair* reg_fns, size_t app_reg_count,
              void (* update_fn)(void), void (* reset_fn)(void));
@@ -53,6 +54,7 @@ public:
                           uint8_t harp_version_major, uint8_t harp_version_minor,
                           uint8_t fw_version_major, uint8_t fw_version_minor,
                           uint16_t serial_number, const char name[],
+                          const uint8_t tag[],
                           void* app_reg_values, RegSpecs* app_reg_specs,
                           RegFnPair* reg_fns, size_t app_reg_count,
                           void (* update_fn)(void), void (*reset_fn)(void));

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -12,6 +12,7 @@
 #include <hardware/structs/timer.h>
 #include <pico/divider.h> // for fast hardware division with remainder.
 #include <hardware/timer.h>
+#include <pico/unique_id.h>
 
 #define NO_PC_INTERVAL_US (3'000'000UL) // Threshold duration. If the connection
                                         // with the PC has been inactive for
@@ -45,7 +46,8 @@ protected: // protected, but not private, to enable derived class usage.
              uint8_t assembly_version,
              uint8_t harp_version_major, uint8_t harp_version_minor,
              uint8_t fw_version_major, uint8_t fw_version_minor,
-             uint16_t serial_number, const char name[]);
+             uint16_t serial_number, const char name[],
+             const uint8_t tag[]);
 
     ~HarpCore();
 
@@ -64,7 +66,8 @@ public:
                           uint8_t assembly_version,
                           uint8_t harp_version_major, uint8_t harp_version_minor,
                           uint8_t fw_version_major, uint8_t fw_version_minor,
-                          uint16_t serial_number, const char name[]);
+                          uint16_t serial_number, const char name[],
+                          const uint8_t tag[]);
 
     static inline HarpCore* self = nullptr; // pointer to the singleton instance.
     static HarpCore& instance() {return *self;} ///< returns the singleton.
@@ -459,7 +462,9 @@ private:
         {&HarpCore::read_reg_generic, &HarpCore::write_device_name},
         {&HarpCore::read_reg_generic, &HarpCore::write_serial_number},
         {&HarpCore::read_reg_generic, &HarpCore::write_clock_config},
-        {&HarpCore::read_reg_generic, &HarpCore::write_timestamp_offset}
+        {&HarpCore::read_reg_generic, &HarpCore::write_timestamp_offset},
+        {&HarpCore::read_reg_generic, &HarpCore::write_to_read_only_reg_error},
+        {&HarpCore::read_reg_generic, &HarpCore::write_to_read_only_reg_error},
     };
 };
 

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -274,6 +274,22 @@ public:
     static void force_state(op_mode_t next_state)
     {self->update_state(true, next_state);}
 
+/**
+ * \brief set the 16 bytews in the R_UUID register. Any unspecified bytes will
+ *  be set to zero.
+ * Usage:
+ * \code
+ *  uint64_t uuid = 0xCAFE;
+ *  // This works as-is on little-endian systems.
+ *  HarpCore::set_uuid((uin8_t*)&uuid, sizeof(uuid));
+ * \endcode
+ */
+    static void set_uuid(uint8_t* uuid, size_t num_bytes, size_t offset = 0)
+    {
+        memset(self->regs.R_UUID, 0, sizeof(self->regs.R_UUID));
+        memcpy((void*)(&self->regs.R_UUID[offset]), (void*)uuid, num_bytes);
+    }
+
 protected:
 /**
  * \brief entry point for handling incoming harp messages to core registers.
@@ -319,7 +335,6 @@ protected:
 
     virtual const RegSpecs& address_to_app_reg_specs(uint8_t address)
     {return regs_.address_to_specs[0];} // should never happen.
-
 
 /**
  * \brief flag indicating whether or not a new message is in the #rx_buffer_.

--- a/firmware/src/core_registers.cpp
+++ b/firmware/src/core_registers.cpp
@@ -16,7 +16,9 @@ Registers::Registers(uint16_t who_am_i,
        .R_FW_VERSION_H = fw_version_major,
        .R_FW_VERSION_L = fw_version_minor,
        .R_OPERATION_CTRL = 0,
-       .R_SERIAL_NUMBER = serial_number}
+       .R_SERIAL_NUMBER = serial_number,
+       .R_UUID = {0} // all zeros.
+        }
 {
     strcpy((char*)regs_.R_DEVICE_NAME, name);
     strcpy((char*)regs_.R_TAG, (char*)tag);

--- a/firmware/src/core_registers.cpp
+++ b/firmware/src/core_registers.cpp
@@ -5,7 +5,8 @@ Registers::Registers(uint16_t who_am_i,
                      uint8_t assembly_version,
                      uint8_t harp_version_major, uint8_t harp_version_minor,
                      uint8_t fw_version_major, uint8_t fw_version_minor,
-                     uint16_t serial_number, const char name[])
+                     uint16_t serial_number, const char name[],
+                     const uint8_t tag[])
 :regs_{.R_WHO_AM_I = who_am_i,
        .R_HW_VERSION_H = hw_version_major,
        .R_HW_VERSION_L = hw_version_minor,
@@ -18,6 +19,7 @@ Registers::Registers(uint16_t who_am_i,
        .R_SERIAL_NUMBER = serial_number}
 {
     strcpy((char*)regs_.R_DEVICE_NAME, name);
+    strcpy((char*)regs_.R_TAG, (char*)tag);
 }
 
 

--- a/firmware/src/harp_c_app.cpp
+++ b/firmware/src/harp_c_app.cpp
@@ -6,6 +6,7 @@ HarpCApp& HarpCApp::init(uint16_t who_am_i,
                          uint8_t harp_version_major, uint8_t harp_version_minor,
                          uint8_t fw_version_major, uint8_t fw_version_minor,
                          uint16_t serial_number, const char name[],
+                         const uint8_t tag[],
                          void* app_reg_values, RegSpecs* app_reg_specs,
                          RegFnPair* app_reg_fns, size_t app_reg_count,
                          void (* update_fn)(void), void (* reset_fn)(void))
@@ -14,8 +15,8 @@ HarpCApp& HarpCApp::init(uint16_t who_am_i,
                         assembly_version,
                         harp_version_major, harp_version_minor,
                         fw_version_major, fw_version_minor, serial_number,
-                        name, app_reg_values, app_reg_specs, app_reg_fns,
-                        app_reg_count, update_fn, reset_fn);
+                        name, tag, app_reg_values, app_reg_specs,
+                        app_reg_fns, app_reg_count, update_fn, reset_fn);
     return app;
 }
 
@@ -25,6 +26,7 @@ HarpCApp::HarpCApp(uint16_t who_am_i,
                    uint8_t harp_version_major, uint8_t harp_version_minor,
                    uint8_t fw_version_major, uint8_t fw_version_minor,
                    uint16_t serial_number, const char name[],
+                   const uint8_t tag[],
                    void* app_reg_values, RegSpecs* app_reg_specs,
                    RegFnPair* app_reg_fns, size_t app_reg_count,
                    void (*update_fn)(void), void (* reset_fn)(void))
@@ -36,7 +38,7 @@ HarpCApp::HarpCApp(uint16_t who_am_i,
  reset_fn_{update_fn},
  HarpCore(who_am_i, hw_version_major, hw_version_minor,
           assembly_version, harp_version_major, harp_version_minor,
-          fw_version_major, fw_version_minor, serial_number, name)
+          fw_version_major, fw_version_minor, serial_number, name, tag)
 {
     // Call base class constructor.
     // Create a ptr to the first (and only) derived class instance created.

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -40,6 +40,8 @@ HarpCore::HarpCore(uint16_t who_am_i,
     pico_unique_board_id_t unique_id;
     pico_get_unique_board_id(&unique_id);
     memcpy((void*)(&regs.R_UUID[8]), (void*)&(unique_id.id), sizeof(unique_id.id));
+#else
+#pragma warning("Harp Core Register UUID will not autodetected for this board.")
 #endif
 }
 

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -5,14 +5,15 @@ HarpCore& HarpCore::init(uint16_t who_am_i,
                          uint8_t assembly_version,
                          uint8_t harp_version_major, uint8_t harp_version_minor,
                          uint8_t fw_version_major, uint8_t fw_version_minor,
-                         uint16_t serial_number, const char name[])
+                         uint16_t serial_number, const char name[],
+                         const uint8_t tag[])
 {
     // Create the singleton instance using the private constructor.
     static HarpCore core(who_am_i, hw_version_major, hw_version_minor,
                          assembly_version,
                          harp_version_major, harp_version_minor,
                          fw_version_major, fw_version_minor, serial_number,
-                         name);
+                         name, tag);
     return core;
 }
 
@@ -21,10 +22,11 @@ HarpCore::HarpCore(uint16_t who_am_i,
                    uint8_t assembly_version,
                    uint8_t harp_version_major, uint8_t harp_version_minor,
                    uint8_t fw_version_major, uint8_t fw_version_minor,
-                   uint16_t serial_number, const char name[])
-:regs_{who_am_i, hw_version_major, hw_version_minor,assembly_version,
+                   uint16_t serial_number, const char name[],
+                   const uint8_t tag[])
+:regs_{who_am_i, hw_version_major, hw_version_minor, assembly_version,
        harp_version_major, harp_version_minor,
-       fw_version_major, fw_version_minor, serial_number, name},
+       fw_version_major, fw_version_minor, serial_number, name, tag},
  rx_buffer_index_{0}, total_bytes_read_{rx_buffer_index_}, new_msg_{false},
  set_visual_indicators_fn_{nullptr}, sync_{nullptr}, offset_us_64_{0},
  disconnect_handled_{false}, connect_handled_{false}
@@ -33,6 +35,12 @@ HarpCore::HarpCore(uint16_t who_am_i,
     if (self == nullptr)
         self = this;
     tusb_init();
+#if defined(PICO_RP2040)
+    // Populate Harp Core R_UUID with unique id from QSPI Flash.
+    pico_unique_board_id_t unique_id;
+    pico_get_unique_board_id(&unique_id);
+    memcpy((void*)(&regs.R_UUID[8]), (void*)&(unique_id.id), sizeof(unique_id.id));
+#endif
 }
 
 HarpCore::~HarpCore(){self = nullptr;}


### PR DESCRIPTION
`R_UUID` and `R_TAG` are now implemented.

If `PICO_RP2040` is defined (default for the pico-sdk), then the lower 8 bytes (bytes 8-15) will be populated with the 8-byte sequence from the QSPI flash upon instantiation of a HarpCore. This 64-bit value is unique per flash chip instance, making it a good default value to stuff into this register.

For the `R_TAG` register, an 8 byte sequence must be added into the constructor.
For folks using CMake (most-likely true if you're using this project), you can stuff it with a string representation of the 7-byte short Git hash by adding the following to your CMakeLists.txt:
````CMakeLists.txt
find_package(Git REQUIRED)
execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
message(STATUS "Computed Git Hash: ${COMMIT_ID}")
add_definitions(-DGIT_HASH="${COMMIT_ID}") # Usable in source code.
````
After that, you can simply use `GIT_HASH` in your source code.

## References:
Implements https://github.com/harp-tech/protocol/pull/38 and https://github.com/harp-tech/protocol/pull/39