### PR TITLE
implement dfu over harp protocol

### DIFF
--- a/firmware/inc/core_registers.h
+++ b/firmware/inc/core_registers.h
@@ -16,8 +16,10 @@ static const uint8_t CORE_REG_COUNT = 18;
 #define OPLEDEN_OFFSET (6)
 #define ALIVE_EN_OFFSET (7)
 
-// RESET_DEF bitfields
-#define RST_DEF_OFFSET (0)
+// RESET_DEV bitfields
+#define RST_DEV_OFFSET (0)
+#define BOOT_DEF_OFFSET (6)
+#define BOOT_EE_OFFSET (7)
 
 /**
  * \brief enum for easier interpretation of the OP_MODE bitfield in the

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -13,6 +13,7 @@
 #include <pico/divider.h> // for fast hardware division with remainder.
 #include <hardware/timer.h>
 #include <pico/unique_id.h>
+#include <pico/bootrom.h>
 
 #define NO_PC_INTERVAL_US (3'000'000UL) // Threshold duration. If the connection
                                         // with the PC has been inactive for
@@ -447,7 +448,7 @@ private:
     static void write_timestamp_second(msg_t& msg);
     static void write_timestamp_microsecond(msg_t& msg);
     static void write_operation_ctrl(msg_t& msg);
-    static void write_reset_def(msg_t& msg);
+    static void write_reset_dev(msg_t& msg);
     static void write_device_name(msg_t& msg);
     static void write_serial_number(msg_t& msg);
     static void write_clock_config(msg_t& msg);
@@ -473,7 +474,7 @@ private:
         {&HarpCore::read_timestamp_second, &HarpCore::write_timestamp_second},
         {&HarpCore::read_timestamp_microsecond, &HarpCore::write_timestamp_microsecond},
         {&HarpCore::read_reg_generic, &HarpCore::write_operation_ctrl},
-        {&HarpCore::read_reg_generic, &HarpCore::write_reset_def},
+        {&HarpCore::read_reg_generic, &HarpCore::write_reset_dev},
         {&HarpCore::read_reg_generic, &HarpCore::write_device_name},
         {&HarpCore::read_reg_generic, &HarpCore::write_serial_number},
         {&HarpCore::read_reg_generic, &HarpCore::write_clock_config},

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -413,17 +413,23 @@ void HarpCore::write_operation_ctrl(msg_t& msg)
     }
 }
 
-void HarpCore::write_reset_def(msg_t& msg)
+void HarpCore::write_reset_dev(msg_t& msg)
 {
     uint8_t& write_byte = *((uint8_t*)msg.payload);
     // R_RESET_DEV Register state does not need to be updated since writing to
     // it only triggers behavior.
     // Tease out relevant flags.
-    const bool& rst_def_bit = bool((write_byte >> RST_DEF_OFFSET) & 1u);
+    const bool& rst_dev_bit = bool((write_byte >> RST_DEV_OFFSET) & 1u);
+    const bool& boot_def_bit = bool((write_byte >> BOOT_DEF_OFFSET) & 1u);
+    const bool& boot_ee_bit = bool((write_byte >> BOOT_EE_OFFSET) & 1u);
     // Issue a harp reply only if we aren't resetting.
     // TODO: unclear if this is the appropriate behavior.
     // Reset if specified to do so.
-    if (rst_def_bit)
+#if defined(PICO_RP2040)
+    if (boot_def_bit && boot_ee_bit)
+        reset_usb_boot(0,0);
+#endif
+    if (rst_dev_bit)
     {
         // Reset core state machine and app.
         self->regs_.r_operation_ctrl_bits.OP_MODE = STANDBY;

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -41,7 +41,7 @@ HarpCore::HarpCore(uint16_t who_am_i,
     pico_get_unique_board_id(&unique_id);
     memcpy((void*)(&regs.R_UUID[8]), (void*)&(unique_id.id), sizeof(unique_id.id));
 #else
-#pragma warning("Harp Core Register UUID will not autodetected for this board.")
+#pragma warning("Harp Core Register UUID not autodetected for this board.")
 #endif
 }
 
@@ -428,6 +428,8 @@ void HarpCore::write_reset_dev(msg_t& msg)
 #if defined(PICO_RP2040)
     if (boot_def_bit && boot_ee_bit)
         reset_usb_boot(0,0);
+#else
+#pragma warning("Boot-to-DFU-mode via Harp Protocol not supported for this device.")
 #endif
     if (rst_dev_bit)
     {


### PR DESCRIPTION
Needs testing.

Setting `BOOT_EE` and `BOOT_DEF` bits simultaneously will trigger RP2040 devices to go into usb boot mode where they appear as USB mass storage devices.

## References
* [Harp Protocol RESET_DEV Register](https://harp-tech.org/protocol/Device.html#r_reset_dev-u8--reset-device-and-save-non-volatile-registers)
* [Harp Protocol DFU Boot Feature Request](https://github.com/harp-tech/protocol/issues/18)