### PR TITLE
add send_harp_reply with specific timestamp

### DIFF
--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -269,7 +269,7 @@ public:
  * \note the returned seconds are rounded down to the most recent second that
  *  has elapsed.
  */
-    static uint32_t harp_time_s()
+    static inline uint32_t harp_time_s()
     {
         self->update_timestamp_regs(); // calls harp_time_us_64() internally.
         return self->regs.R_TIMESTAMP_SECOND;

--- a/firmware/inc/harp_synchronizer.h
+++ b/firmware/inc/harp_synchronizer.h
@@ -110,8 +110,8 @@ public:
  *  local time domain, which is monotonic and unchanged by adjustments to
  *  the harp time.
  */
-    static inline uint32_t harp_to_system_us_32(uint32_t harp_time_us)
-    {return harp_time_us + uint32_t(self->offset_us_64_);}
+    static inline uint32_t harp_to_system_us_32(uint64_t harp_time_us)
+    {return uint32_t(harp_to_system_us_64(harp_time_us));}
 
 /**
  * \brief true if the synchronizer has received at least one external sync

--- a/firmware/inc/harp_synchronizer.h
+++ b/firmware/inc/harp_synchronizer.h
@@ -11,7 +11,7 @@
 #include <cstdio> // for printf
 #endif
 
-#define HARP_SYNC_BAUDRATE (100000UL)
+#define HARP_SYNC_BAUDRATE (100'000UL)
 #define HARP_SYNC_DATA_BITS (8)
 #define HARP_SYNC_STOP_BITS (1)
 #define HARP_SYNC_PARITY (UART_PARITY_NONE)
@@ -54,12 +54,34 @@ public:
     static HarpSynchronizer& instance(){return *self;}
 
 /**
+ * \brief convert system time (in 64-bit microseconds) to local system time
+ *  (in 64-bit microseconds)
+ * \details this utility function is useful for timestamping events in the
+ *  local time domain and then calculating when they happened in Harp time.
+ * \note if the device is unsynchronized (i.e: offset = 0), the returned time
+ *  will be in local system time.
+ */
+    static inline uint64_t system_to_harp_us_64(uint64_t system_time_us)
+    {return system_time_us - self->offset_us_64_;}
+
+/**
+ * \brief Override the current Harp time with a specific time.
+ * \note useful if a separate entity besides the synchronizer input jack
+ *  needs to set the time (i.e: specifying the time over Harp protocol by
+ *  writing to timestamp registers).
+ */
+    static inline void set_harp_time_us_64(uint64_t harp_time_us)
+    {self->offset_us_64_ = ::time_us_64() - harp_time_us;}
+
+/**
  * \brief get the total elapsed microseconds (64-bit) in "Harp" time.
  * \warning this value is not monotonic and can change at any time if an
  *  external synchronizer is physically connected and operating.
+ * \note if the device is unsynchronized (i.e: offset = 0), the returned time
+ *  will be in local system time.
  */
     static inline uint64_t time_us_64()
-    {return ::time_us_64() - self->offset_us_64_;}
+    {return system_to_harp_us_64(::time_us_64());}
 
 /**
  * \brief get the total elapsed microseconds (32-bit) in "Harp" time.


### PR DESCRIPTION
We can now send a harp reply with any timestamp we want (in harp time) instead of the time at which the `send_harp_reply` function was called. This is useful if data needs to be timestamped close to where it was captured, but there is delay when it will be dispatched out of the device.

````cpp
// Core1: capture the data when it happens.
if (new_lick_states != lick_states)
{
    lick_states = new_lick_states;
    lick_event.state = lick_states;
    lick_event.pico_time_us = time_us_64();
    queue_try_add(&lick_event_queue, &lick_event);
}
````

````cpp
// Core0: dispatch the data later with a Harp timestamp.
app_regs.lick_state = new_lick_state.state; // Update the app register.
uint64_t lick_harp_time_us = HarpCore::system_to_harp_us_64(new_lick_state.pico_time_us);
HarpCApp::send_harp_reply(EVENT, LICK_STATE_REG, lick_harp_time_us);
````



Addresses https://github.com/AllenNeuralDynamics/harp.core.rp2040/issues/37