### PR TITLE
update CMakLists for rp2350

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(harp_sync PUBLIC inc)
 target_include_directories(harp_core PUBLIC inc)
 
 
-target_link_libraries(usb_desc tinyusb_device pico_unique_id)
+target_link_libraries(usb_desc tinyusb_device pico_unique_id pico_stdlib)
 target_link_libraries(harp_sync pico_stdlib)
 target_link_libraries(harp_core core_registers pico_stdlib tinyusb_device usb_desc)
 target_link_libraries(harp_c_app harp_core)


### PR DESCRIPTION
Per this hack https://github.com/raspberrypi/pico-sdk/issues/1929 , we need to add an extra dependency to compile `usb_desc`, but after doing so Pico SDK 2.0.0 should now be compatible.