### PR TITLE
for rp2040 get uinique id from flash

### DIFF
--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -14,6 +14,9 @@
 #include <hardware/timer.h>
 #include <pico/unique_id.h>
 #include <pico/bootrom.h>
+#if defined(PICO_RP2040) // Invoke pico-specific fast-integer-division hardware.
+    #include <hardware/flash.h>
+#endif
 
 #define HARP_VERSION_MAJOR (0)
 #define HARP_VERSION_MINOR (0)

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -38,9 +38,11 @@ HarpCore::HarpCore(uint16_t who_am_i,
     tusb_init();
 #if defined(PICO_RP2040)
     // Populate Harp Core R_UUID with unique id from QSPI Flash.
-    pico_unique_board_id_t unique_id;
-    pico_get_unique_board_id(&unique_id);
-    memcpy((void*)(&regs.R_UUID[8]), (void*)&(unique_id.id), sizeof(unique_id.id));
+    uint8_t flash_id[16]; // flash id is 8 bytes long, so zero out the rest.
+    for (size_t i = 0; i < 16; ++i)
+        flash_id[i] = 0;
+    flash_get_unique_id(flash_id);
+    memcpy((void*)(&regs.R_UUID[0]), (void*)&(flash_id), sizeof(flash_id));
 #else
 #pragma warning("Harp Core Register UUID not autodetected for this board.")
 #endif


### PR DESCRIPTION
On the RP2040, pull the ID from the flash chip. (The current API sometimes reads all-zeros when calling `get_unique_board_id`.) Also fix an endianness issue where the wrong byte range was being populated.

Partially addresses https://github.com/harp-tech/core.pico/issues/62 for the rp2040.