### PR TITLE
Feat enums and write only fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ For more information on reading data or writing commands to your custom new harp
   * if events in system time need to be timestamped in *Harp time*.
 ---
 # Developer Notes
-
+### Bumping the Version
+There are two semantic versions to keep track of:
+* `HARP_VERSION_MAJOR`, `*_MINOR`, `*_PATCH`
+  * tracks the [Harp Protocol Version](https://harp-tech.org/protocol/BinaryProtocol-8bit.html#release-notes) that this library best implements.
+  * Bump this version when this library implements features in a future Harp Protocol Version.
+* `PICO_CORE_VERSION_MAJOR`, `*_MINOR`, `*_PATCH`
+  * is the version of this project. This version can vary freely from `HARP_VERSION_*` and is for tracking the API of the project.
+  * Bump this version when you make changes to this library.
+ 
 ### Debugging with printf
 The Harp Core consumes the USB serial port, so `printf` messages must be rerouted to an available UART port.
 The Pico SDK makes this step fairly straightforward. Before calling `printf` you must first setup a UART port with:

--- a/examples/harp_c_app_example/README.md
+++ b/examples/harp_c_app_example/README.md
@@ -1,42 +1,97 @@
-# Compiling and Flashing this Example
+# harp.device.pico-template
 
-## Setting up the Build Environment
+An RP2040-based Harp hardware/firmware project template.
 
-### Install Pico SDK
-This project uses the [Pico SDK](https://github.com/raspberrypi/pico-sdk/tree/master).
-The SDK needs to be downloaded and installed to a known folder on your PC.
-Note that the PICO SDK also contains submodules (including TinyUSB), so you must ensure that they are also fetched with:
-````
-git clone git@github.com:raspberrypi/pico-sdk.git
-git submodule update --init
-````
+## Features
+* predefined *.gitignore* file to remove extraneous KiCAD (hardware) files.
+### Hardware
+* Schematic template for a generic Harp Device including:
+  * ground-isolated Full Speed USB communication
+  * 3.5mm audio jack for Harp-protocol time synchronization
+  * RP2040 MCU and required "jellybean" components including:
+    * 2MB external flash (Winbond MPN: W25Q16JVUXIQ TR).
+  * 2 power supply chain options for power derived from either USB directly or from a DC barrel jack.
+* Basic PCBA Layout with size hints for various existing enclosures
+  * DC Barrel Jack (2.1 x 5.5mm, positive center)
+  * USBC
+  * 3.5mm audio jack for Harp synchronization signal
+  * Ground lug
+### Firmware
+* basic "hello-world" project with corresponding file structure
+* populated CMakeLists.txt for compliation
+* placeholder USB descriptors for Manufacturer and Description fields (in the CMakeLists.txt)
+* compilation [instructions](./firmware/README.md)
+* harp protocol core library included as a submodule [harp.core.pico](https://github.com/AllenNeuralDynamics/harp.core.pico)
 
-### Point to Pico SDK
-Recommended, but optional: define the `PICO_SDK_PATH` environment variable to point to the location where the pico-sdk was downloaded. i.e:
-````
-PICO_SDK_PATH=/home/username/projects/pico-sdk
-````
-On Linux, it may be preferrable to put this in your `.bashrc` file.
+# Using this template
+Start by clicking the "Use this Template" button in the upper right corner, or click [here](https://github.com/new?template_name=harp.device.pico-template&template_owner=AllenNeuralDynamics).
+## Repository Setup
+* If the project has a corresponding Allen Institute SIPE project number, prepend the repository description with: `{SIPE Project Number}:`.
+* add the tag `Harp`
+* Long-term: remove these instructions!
 
-## Compiling the Firmware
+## Hardware
+* Remove all unused hardware folder starter projects.
+* 🔧 Design your hardware.
+* In the PCBA silkscreen, add:
+  * SIPE part number with full hardware semantic version appended in the format: `{SIPE Project Number}-E-{hw major}-{hw minor}-{hw patch}`. Version number fields range from 1-999 and include leading zeros.
+  * [QR code](https://www.the-qrcode-generator.com/) linking to the Github repository.
 
-### Without an IDE
-From this directory, create a directory called build, enter it, and invoke cmake with:
-````
-mkdir build
-cd build
-cmake ..
-````
-If you did not define the `PICO_SDK_PATH` as an environment variable, you must pass it in here like so:
-````
-mkdir build
-cd build
-cmake -DPICO_SDK_PATH=/path/to/pico-sdk ..
-````
-After this point, you can invoke the auto-generated Makefile with `make`
+## Firmware
+* Update the *Manufacturer* and *Description* USB descriptors in the CMakeLists.txt
+* 📝 Write your firmware.
 
-## Flashing the Firmware
-Press-and-hold the Pico's BOOTSEL button and power it up (i.e: plug it into usb).
-At this point you do one of the following:
-* drag-and-drop the created **\*.uf2** file into the mass storage device that appears on your pc.
-* flash with [picotool](https://github.com/raspberrypi/picotool)
+# Github Release Conventions
+Releases specify any vetted changes to the hardware or firmware.
+
+Each release specifies:
+* semantic versions of changed elements: hardware or firmware.
+* SIPE part number (or part numbers if multiple are compatible)
+
+Each hardware release includes:
+* STEP file of the PCB (or link to corresponding CAD files) named with the SIPE part number
+* schematic (PDF)
+* Gerber files (with logos removed) of the PCBA
+* Position files for component placement
+* Bill-of-Materials for the PCBA
+
+Each hardware release specifies:
+* compatible SIPE part number(s)
+
+> [!NOTE]
+> SIPE part numbers only encode hardware semantic version major number, so multiple minor/patch hardware releases may point to the same SIPE part number.
+
+> [!NOTE]
+> It is possible for a project to have PCBA variants--possibly with very different functionality. In this case, reserve a hardware major version range (>100 suggested) for this variant and treat it as a distinct hardware release (i.e: with all corresponding included hardware files).
+
+
+Each firmware release specifies:
+* firmware semantic version
+* compatible hardware (SIPE part number or part number range).
+
+Each firmware release includes:
+* compiled binary file (**\*.uf2**) of the firmware.
+
+## Release Title
+The release title is specified as follows:
+
+`hw{hw major}.{hw minor}.{hw patch}-fw{fw major}.{fw minor}.{fw patch}`
+
+If the release has firmware-only changes, you can drop the `hw*` section, and vice versa.
+
+> [!NOTE]
+> After Oct 2024, hardware major fields on all future releases will be equivalent to the major version number of the SIPE part number. See the [SIPE PCBA part numbering standard](https://alleninstitute.sharepoint.com/:w:/s/Instrumentation/EYsRN8q4jHJDmG5DNf-gaM0Bq418YMXollFxtB9d_NZ6pg?e=joLAvU) for more details.
+
+The above field spec enables automation utilities to find the latest firmware version and automatically update compatible hardware. Since releases can include changes to some, but not other fields, unchanged fields are omitted. (i.e: firmware-only changes would be titled `fw{fw major}.{fw minor}.{fw patch}`.)
+
+## Creating a New Release
+1. Make a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) based on the commit in the main branch that you'd like to create the release from. Use the naming convention specified in the [Release Title](#release-title) section.
+2. Push the tag to Github.
+3. From the repository's corresponding *Release* page, create a new release from the tag you just added. Give it the same title as the tag.
+4. If the release includes new _firmware_, compile it locally, and upload a copy of the *.uf2* file as an attachment.
+5. If the release includes new _hardware_, upload:
+    1. the gerber files (zipped)
+    2. the position files
+    3. any manufacturing notes (component orientations)
+    4. the bill-of-materials
+    5. a PDF of the schematic.

--- a/examples/harp_c_app_example/README.md
+++ b/examples/harp_c_app_example/README.md
@@ -1,97 +1,97 @@
-# harp.device.pico-template
+There are two sets of instructions, one for [Windows](#windows-setup) and one for [Linux](linux-setup).
 
-An RP2040-based Harp hardware/firmware project template.
 
-## Features
-* predefined *.gitignore* file to remove extraneous KiCAD (hardware) files.
-### Hardware
-* Schematic template for a generic Harp Device including:
-  * ground-isolated Full Speed USB communication
-  * 3.5mm audio jack for Harp-protocol time synchronization
-  * RP2040 MCU and required "jellybean" components including:
-    * 2MB external flash (Winbond MPN: W25Q16JVUXIQ TR).
-  * 2 power supply chain options for power derived from either USB directly or from a DC barrel jack.
-* Basic PCBA Layout with size hints for various existing enclosures
-  * DC Barrel Jack (2.1 x 5.5mm, positive center)
-  * USBC
-  * 3.5mm audio jack for Harp synchronization signal
-  * Ground lug
-### Firmware
-* basic "hello-world" project with corresponding file structure
-* populated CMakeLists.txt for compliation
-* placeholder USB descriptors for Manufacturer and Description fields (in the CMakeLists.txt)
-* compilation [instructions](./firmware/README.md)
-* harp protocol core library included as a submodule [harp.core.pico](https://github.com/AllenNeuralDynamics/harp.core.pico)
+# Windows Setup
 
-# Using this template
-Start by clicking the "Use this Template" button in the upper right corner, or click [here](https://github.com/new?template_name=harp.device.pico-template&template_owner=AllenNeuralDynamics).
-## Repository Setup
-* If the project has a corresponding Allen Institute SIPE project number, prepend the repository description with: `{SIPE Project Number}:`.
-* add the tag `Harp`
-* Long-term: remove these instructions!
-
-## Hardware
-* Remove all unused hardware folder starter projects.
-* 🔧 Design your hardware.
-* In the PCBA silkscreen, add:
-  * SIPE part number with full hardware semantic version appended in the format: `{SIPE Project Number}-E-{hw major}-{hw minor}-{hw patch}`. Version number fields range from 1-999 and include leading zeros.
-  * [QR code](https://www.the-qrcode-generator.com/) linking to the Github repository.
-
-## Firmware
-* Update the *Manufacturer* and *Description* USB descriptors in the CMakeLists.txt
-* 📝 Write your firmware.
-
-# Github Release Conventions
-Releases specify any vetted changes to the hardware or firmware.
-
-Each release specifies:
-* semantic versions of changed elements: hardware or firmware.
-* SIPE part number (or part numbers if multiple are compatible)
-
-Each hardware release includes:
-* STEP file of the PCB (or link to corresponding CAD files) named with the SIPE part number
-* schematic (PDF)
-* Gerber files (with logos removed) of the PCBA
-* Position files for component placement
-* Bill-of-Materials for the PCBA
-
-Each hardware release specifies:
-* compatible SIPE part number(s)
+Windows has two sub-options for developing:
+* Option A: use Visual Studio Code (easy way)
+* Option B: develop with any IDE and compile from the command line.
 
 > [!NOTE]
-> SIPE part numbers only encode hardware semantic version major number, so multiple minor/patch hardware releases may point to the same SIPE part number.
+> For Option B, simply install [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install), and then follow the directions in the [Linux](#linux-setup) section of this guide. The rest of this section covers Option A.
+  
+## Pre-requisites
+1. Install [Visual Studio Code](https://code.visualstudio.com/).
+2. Install the [Pico Extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=raspberry-pi.raspberry-pi-pico)
 
-> [!NOTE]
-> It is possible for a project to have PCBA variants--possibly with very different functionality. In this case, reserve a hardware major version range (>100 suggested) for this variant and treat it as a distinct hardware release (i.e: with all corresponding included hardware files).
+## Project Setup
+In Visual Studio, click on the Pico icon that appears after installing the Pico Extension. Select _Import Project_ and import the _firmware_ folder of this repository.
+Choose the default options.
 
+## Compiling the Firmware
+Click the _compile_ button at the corner of the screen. When the compilation finishes, you're ready to [flash the firmware](#flashing-the-firmware).
 
-Each firmware release specifies:
-* firmware semantic version
-* compatible hardware (SIPE part number or part number range).
+# Linux Setup
 
-Each firmware release includes:
-* compiled binary file (**\*.uf2**) of the firmware.
+## Pre-requisites
 
-## Release Title
-The release title is specified as follows:
+You will need CMake, make, and the gcc-arm-embedded toolchain.
 
-`hw{hw major}.{hw minor}.{hw patch}-fw{fw major}.{fw minor}.{fw patch}`
+On Linux, install the following:
+```bash
+sudo apt install cmake python3 build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+```
 
-If the release has firmware-only changes, you can drop the `hw*` section, and vice versa.
+### Install Submodules
+This project uses the Harp [core.pico](https://github.com/harp-tech/core.pico) library as a submodule.
+Install it with:
+````
+git submodule update --init
+````
 
-> [!NOTE]
-> After Oct 2024, hardware major fields on all future releases will be equivalent to the major version number of the SIPE part number. See the [SIPE PCBA part numbering standard](https://alleninstitute.sharepoint.com/:w:/s/Instrumentation/EYsRN8q4jHJDmG5DNf-gaM0Bq418YMXollFxtB9d_NZ6pg?e=joLAvU) for more details.
+### Install Pico SDK
+This project uses the [Pico SDK](https://github.com/raspberrypi/pico-sdk/tree/master).
+The SDK needs to be downloaded and installed to a known folder on your PC.
+Note that the PICO SDK also contains submodules (including TinyUSB), so you must ensure that they are also fetched with:
+````
+git clone git clone git@github.com:raspberrypi/pico-sdk.git
+git submodule update --init --recursive
+````
 
-The above field spec enables automation utilities to find the latest firmware version and automatically update compatible hardware. Since releases can include changes to some, but not other fields, unchanged fields are omitted. (i.e: firmware-only changes would be titled `fw{fw major}.{fw minor}.{fw patch}`.)
+### Point to Pico SDK
+Optional: define the `PICO_SDK_PATH` environment variable to point to the location where the pico-sdk was downloaded. i.e:
+````
+PICO_SDK_PATH=/home/username/projects/pico-sdk
+````
+On Linux, you can define it in your `.bashrc` file.
+On Windows, you can define it via System Properties ([tutorial](https://www.computerhope.com/issues/ch000549.htm)).
 
-## Creating a New Release
-1. Make a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) based on the commit in the main branch that you'd like to create the release from. Use the naming convention specified in the [Release Title](#release-title) section.
-2. Push the tag to Github.
-3. From the repository's corresponding *Release* page, create a new release from the tag you just added. Give it the same title as the tag.
-4. If the release includes new _firmware_, compile it locally, and upload a copy of the *.uf2* file as an attachment.
-5. If the release includes new _hardware_, upload:
-    1. the gerber files (zipped)
-    2. the position files
-    3. any manufacturing notes (component orientations)
-    4. the bill-of-materials
-    5. a PDF of the schematic.
+Confirm that the environment variable is applied to your system by opening a terminal (Powershell on Windows) and
+entering (with the `$` sign)
+```bash
+$PICO_SDK_PATH
+```
+to confirm that the path was defined correctly.
+(Windows may require a restart for the environment variable to take effect.)
+
+## Compiling the Firmware
+
+### With the Visual Studio Code Extension
+Using the Pico extension, import the *firmware* folder with the default options.
+
+Click the compile button.
+
+### Without an IDE
+From within this folder, create a new folder called *build*, enter it, and invoke cmake with:
+````
+mkdir build
+cd build
+cmake ..
+````
+If you did not define the `PICO_SDK_PATH` as an environment variable, you must pass it in here like so:
+````
+mkdir build
+cd build
+cmake -DPICO_SDK_PATH=/path/to/pico-sdk ..
+````
+After this point, you can invoke the auto-generated Makefile with `make`
+
+## Flashing the Firmware
+Press-and-hold the Pico's BOOTSEL button and power it up (i.e: plug it into usb).
+At this point you do one of the following:
+* drag-and-drop the created **\*.uf2** file into the mass storage device that appears on your pc.
+* flash with [picotool](https://github.com/raspberrypi/picotool)
+
+# References
+* [YouTube: How to Set Up Visual Studio Code to Program the Pi Pico (Windows)](https://www.youtube.com/watch?v=mUF9xjDtFfY&t=55s)
+* [Pico SDK: Unix Command Line](https://github.com/raspberrypi/pico-sdk?tab=readme-ov-file#unix-command-line) Setup

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 
 project(harp_core_rp2040)
 
-# Use modern conventions like std::invoke
-set(CMAKE_CXX_STANDARD 17)
+# Use modern conventions like `using enum <enum_name>` (20) and `std::to_underlying` (23)
+set(CMAKE_CXX_STANDARD 23)
 
 add_library(core_registers
     src/core_registers.cpp

--- a/firmware/inc/core_registers.h
+++ b/firmware/inc/core_registers.h
@@ -95,6 +95,8 @@ struct RegSpecs
 
 struct Registers
 {
+    using enum reg_type_t;
+
     public:
         Registers(uint16_t who_am_i,
                   uint8_t hw_version_major, uint8_t hw_version_minor,

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -7,6 +7,7 @@
 #include <arm_regs.h>
 #include <cstring> // for memcpy
 #include <tusb.h>
+#include <utility> // for std::to_underlying
 
 // Pico-specific includes.
 #include <hardware/structs/timer.h>
@@ -46,6 +47,7 @@ struct RegFnPair
  */
 class HarpCore
 {
+using enum reg_type_t;
 // Make constructor protected to prevent creating instances outside of init().
 protected: // protected, but not private, to enable derived class usage.
     HarpCore(uint16_t who_am_i,
@@ -139,11 +141,23 @@ public:
  */
     static void read_reg_generic(uint8_t reg_name);
 
+
 /**
- * \brief write handler function. Sends a harp reply indicating a write error
- *      to the specified register.
+ * \brief read-error handler function. Send a zero-length payload harp reply
+ *  from the specified register with the reply type set as  `READ_ERROR` to
+ *  indicate a read error.
+ * \note This function is provided for convenience where no payload is
+ *  necessary. For alternate circumstances where a specific payload must be
+ *  used, invoke send_harp_reply() instead.
+ */
+    static void read_from_write_only_reg_error(uint8_t reg_name);
+
+/**
+ * \brief write-error handler function. Send a harp reply indicating a write
+ *  error to the specified register.
  */
     static void write_to_read_only_reg_error(msg_t& msg);
+
 
 /**
  * \brief update local (app or core) register data with the payload provided in

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -16,9 +16,16 @@
 #include <pico/unique_id.h>
 #include <pico/bootrom.h>
 
-#define HARP_VERSION_MAJOR (0)
-#define HARP_VERSION_MINOR (0)
-#define HARP_VERSION_PATCH (0)
+// Project version
+inline constexpr size_t PICO_CORE_VERSION_MAJOR = 0;
+inline constexpr size_t PICO_CORE_VERSION_MINOR = 2;
+inline constexpr size_t PICO_CORE_VERSION_PATCH = 0;
+
+// Version of the Harp Protocol that this library most closely implements.
+inline constexpr size_t HARP_VERSION_MAJOR = 0;
+inline constexpr size_t HARP_VERSION_MINOR = 0;
+inline constexpr size_t HARP_VERSION_PATCH = 0;
+
 
 
 #define NO_PC_INTERVAL_US (3'000'000UL) // Threshold duration. If the connection

--- a/firmware/inc/harp_message.h
+++ b/firmware/inc/harp_message.h
@@ -1,16 +1,19 @@
 #ifndef HARP_MESSAGE_H
 #define HARP_MESSAGE_H
 #include <reg_types.h>
+#include <utility> // for std::to_underlying
 
 #define MAX_PACKET_SIZE (255) // unused?
 
 enum msg_type_t: uint8_t
 {
+    ERROR_MASK = 0x80,
+
     READ = 1,
     WRITE = 2,
     EVENT = 3,
-    READ_ERROR = 9,
-    WRITE_ERROR = 10
+    READ_ERROR = READ | ERROR_MASK,
+    WRITE_ERROR = WRITE | ERROR_MASK
 };
 
 
@@ -19,6 +22,8 @@ enum msg_type_t: uint8_t
 #pragma pack(push, 1)
 struct msg_header_t
 {
+    using enum reg_type_t;
+
     msg_type_t type;
     uint8_t raw_length;
     uint8_t address;
@@ -27,7 +32,8 @@ struct msg_header_t
 
     // (Inline) Member functions:
     bool has_timestamp()
-    {return bool(payload_type & HAS_TIMESTAMP);}
+    {return bool(std::to_underlying(payload_type) &
+                 std::to_underlying(HAS_TIMESTAMP));}
 
     uint8_t payload_length()
     {return has_timestamp()? raw_length - 10: raw_length - 4;}

--- a/firmware/inc/harp_message.h
+++ b/firmware/inc/harp_message.h
@@ -7,7 +7,7 @@
 
 enum msg_type_t: uint8_t
 {
-    ERROR_MASK = 0x80,
+    ERROR_MASK = 0x08,
 
     READ = 1,
     WRITE = 2,

--- a/firmware/inc/reg_types.h
+++ b/firmware/inc/reg_types.h
@@ -1,14 +1,13 @@
 #ifndef REG_TYPES_H
 #define REG_TYPES_H
 
-// Payload flags. These need their type enforced.
-#define IS_SIGNED ((uint8_t)0x80)
-#define IS_FLOAT ((uint8_t)0x40)
-#define HAS_TIMESTAMP ((uint8_t)0x10)
-
-
-enum reg_type_t: uint8_t
+enum class reg_type_t: uint8_t
 {
+    IS_SIGNED = 0x80,
+    IS_FLOAT = 0x40,
+    HAS_TIMESTAMP = 0x10,
+
+
     U8 = 1,
     S8 = IS_SIGNED | U8,
     U16 = 2,

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -256,7 +256,8 @@ void HarpCore::send_harp_reply(msg_type_t reply_type, uint8_t reg_name,
     uint8_t raw_length = num_bytes + 10;
     uint8_t checksum = 0;
     msg_header_t header{reply_type, raw_length, reg_name, 255,
-                        (reg_type_t)(HAS_TIMESTAMP | payload_type)};
+                        reg_type_t(std::to_underlying(HAS_TIMESTAMP) |
+                                   std::to_underlying(payload_type))};
 #ifdef DEBUG_HARP_MSG_OUT
     printf("Sending msg: \r\n");
     printf("  type: %d\r\n", header.type);
@@ -333,6 +334,15 @@ void HarpCore::write_to_read_only_reg_error(msg_t& msg)
     printf("Error: Reg address %d is read-only.\r\n", msg.header.address);
 #endif
     send_harp_reply(WRITE_ERROR, msg.header.address);
+}
+
+void HarpCore::read_from_write_only_reg_error(uint8_t address)
+{
+#ifdef DEBUG_HARP_MSG_IN
+    printf("Error: Reg address %d is write-only.\r\n", address);
+#endif
+    // Send a zero-length reply to keep the transaction short.
+    send_harp_reply(READ_ERROR, address, nullptr, 0, U8);
 }
 
 void HarpCore::set_timestamp_regs(uint64_t harp_time_us)


### PR DESCRIPTION
For larger projects, we're having name collision issues with the `#define`d constants in this project. This PR cleans up some of these `#defines` and replaces them with `inline constexpr` where appropriate. In cases where the `#defines` should be local to the file scope only, these are moved into enum classes or integrated into the enums directly.

Generally we also want to be able to track updates to this library with semantic versioning in a way that's *independent* of the Harp protocol version that the library best implements. To do that, I added a separate set of version constants.

Finally, I added a convenience handler function for reading from a register that should be "write-only."

* Update compilation instructions in the example.
* Add `PICO_CORE_VERSION_MAJOR`, `*_MINOR`, and `*_PATCH` to track the version of this project independent of the Harp Protocol version that the project best implements.
* Update CXX Standard to 23
  * required for `std::to_underlying`
  * required for enum classes (minimum was CXX 20)
* make the `reg_type_t` an enum class to reduce name collisions
* remove enum-related `#define`s which had a name collision with the *etl* library
* make a callback convenience function for handling read from a "write-only" register.

This is a breaking change to the library API because projects that create Harp Apps will need to either:
* rescope all of their usages of `reg_type_t` with: `reg_type_t:U8`, etc. OR
* add `using enum reg_type_t` from **reg_types.h** at the top of function bodies or in class interfaces that want to use the enum without the namespace prefix.