### PR TITLE
make `reg_address_to_specs` static and public

### DIFF
--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -18,7 +18,7 @@
 
 // Project version
 inline constexpr size_t PICO_CORE_VERSION_MAJOR = 0;
-inline constexpr size_t PICO_CORE_VERSION_MINOR = 2;
+inline constexpr size_t PICO_CORE_VERSION_MINOR = 3;
 inline constexpr size_t PICO_CORE_VERSION_PATCH = 0;
 
 // Version of the Harp Protocol that this library most closely implements.

--- a/firmware/inc/harp_core.h
+++ b/firmware/inc/harp_core.h
@@ -172,7 +172,7 @@ public:
  */
     static inline void copy_msg_payload_to_register(msg_t& msg)
     {
-        const RegSpecs& specs = self->reg_address_to_specs(msg.header.address);
+        const RegSpecs& specs = reg_address_to_specs(msg.header.address);
         memcpy((void*)specs.base_ptr, msg.payload, specs.num_bytes);
     }
 
@@ -227,7 +227,7 @@ public:
  */
     static inline void send_harp_reply(msg_type_t reply_type, uint8_t reg_name)
     {
-        const RegSpecs& specs = self->reg_address_to_specs(reg_name);
+        const RegSpecs& specs = reg_address_to_specs(reg_name);
         send_harp_reply(reply_type, reg_name, specs.base_ptr, specs.num_bytes,
                         specs.payload_type);
     }
@@ -245,7 +245,7 @@ public:
     static inline void send_harp_reply(msg_type_t reply_type, uint8_t reg_name,
                                        uint64_t harp_time_us)
     {
-        const RegSpecs& specs = self->reg_address_to_specs(reg_name);
+        const RegSpecs& specs = reg_address_to_specs(reg_name);
         send_harp_reply(reply_type, reg_name, specs.base_ptr, specs.num_bytes,
                         specs.payload_type, harp_time_us);
     }
@@ -400,6 +400,14 @@ public:
         memset(self->regs.R_UUID, 0, sizeof(self->regs.R_UUID));
         memcpy((void*)(&self->regs.R_UUID[offset]), (void*)uuid, num_bytes);
     }
+
+/**
+ * \brief return a reference to the specified core or app register's specs used
+ *  for issuing a harp reply for that register.
+ * \details address	is the full address range where 0 is the first core
+ *  register, and APP_REG_START_ADDRESS is the first app register.
+ */
+    static const RegSpecs& reg_address_to_specs(uint8_t address);
 
 protected:
 /**
@@ -577,14 +585,6 @@ private:
  * \brief Write the a specified Harp time to the timestamp registers.
  */
     static void set_timestamp_regs(uint64_t harp_time_us);
-
-/**
- * \brief return a reference to the specified core or app register's specs used
- *  for issuing a harp reply for that register.
- * \details address	is the full address range where 0 is the first core
- *  register, and APP_REG_START_ADDRESS is the first app register.
- */
-    const RegSpecs& reg_address_to_specs(uint8_t address);
 
     // core register read handler functions. Handles read operations on those
     // registers. One-per-harp-register where necessary, but read_reg_generic()

--- a/firmware/src/harp_core.cpp
+++ b/firmware/src/harp_core.cpp
@@ -241,8 +241,8 @@ void HarpCore::update_state(bool force, op_mode_t forced_next_state)
 const RegSpecs& HarpCore::reg_address_to_specs(uint8_t address)
 {
     if (address < CORE_REG_COUNT)
-        return regs_.address_to_specs[address];
-    return address_to_app_reg_specs(address); // virtual. Implemented by app.
+        return self->regs_.address_to_specs[address];
+    return self->address_to_app_reg_specs(address); // virtual. Implemented by app.
 }
 
 void HarpCore::send_harp_reply(msg_type_t reply_type, uint8_t reg_name,


### PR DESCRIPTION
Make `reg_address_to_specs` static and public so we can call it inside a harp reg write handler function. This is very useful for working back to extract the actual register data from a write handler function that's intended to be generic across multiple registers. (This is currently what's done in the `write_reg_generic function`.)

The benefit of exposing it is that we can work backwards to extract other information like what index the reg data is if that data lives in an array, and we have two register "views" of that data.

Example: we have a register that represents 4 concatenated analog output channel values, and registers that represent each analog output channel individually.

```cpp

uint16_t analog_output_port_state[4];

RegSpecs app_reg_specs
{
    {(uint8_t*)&analog_output_port_state, sizeof(analog_output_port_state), U16},
    {(uint8_t*)&analog_output_port_state[0], sizeof(uint16_t), U16},              
    {(uint8_t*)&analog_output_port_state[1], sizeof(uint16_t), U16},              
    {(uint8_t*)&analog_output_port_state[2], sizeof(uint16_t), U16},              
    {(uint8_t*)&analog_output_port_state[3], sizeof(uint16_t), U16}, 
};

write_any_analog_output_channel(msg_t& msg)
{
    const RegSpecs& specs = address_to_app_reg_specs(msg.header.address);
    // Get channel index using pointer arithmetic.
    uint16_t& channel_index = (uint16_t*)specs.base_ptr - app_reg.analog_outputs;
    // Do something with the channel index.
    // ...
    if (!HarpCore::is_muted())
        HarpCore::send_harp_reply(msg.header.address);
};